### PR TITLE
Please add my vector library 'brinevector'

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,12 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 ## Math
 *Math specific Libraries*
 
-* [Cirno's Perfect Math Library](https://github.com/excessive/cpml) - Math/intersection library designed for games
-* [delaunay](https://github.com/Yonaba/delaunay) - Delaunay triangulation for convex polygons
-* [MLib](https://github.com/davisdude/mlib) - Math and shape-intersection detection library written in Lua. It's aim is to be robust and easy to use
-* [hump.vector](http://hump.readthedocs.io/en/latest/vector.html) - Powerful 2D vector class
 * [Bresenham](https://github.com/rm-code/Bresenham) - Bresenham's line algorithm written in Lua
 * [brinevector](https://github.com/novemberisms/brinevector) - Standalone lightweight luajit ffi-accelerated 2D vector library for great performance
+* [Cirno's Perfect Math Library](https://github.com/excessive/cpml) - Math/intersection library designed for games
+* [delaunay](https://github.com/Yonaba/delaunay) - Delaunay triangulation for convex polygons
+* [hump.vector](http://hump.readthedocs.io/en/latest/vector.html) - Powerful 2D vector class
+* [MLib](https://github.com/davisdude/mlib) - Math and shape-intersection detection library written in Lua. It's aim is to be robust and easy to use
 
 ## Music
 *Music related libraries*

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [MLib](https://github.com/davisdude/mlib) - Math and shape-intersection detection library written in Lua. It's aim is to be robust and easy to use
 * [hump.vector](http://hump.readthedocs.io/en/latest/vector.html) - Powerful 2D vector class
 * [Bresenham](https://github.com/rm-code/Bresenham) - Bresenham's line algorithm written in Lua
+* [brinevector](https://github.com/novemberisms/brinevector) - Standalone lightweight luajit ffi-accelerated 2D vector library for great performance
 
 ## Music
 *Music related libraries*


### PR DESCRIPTION
While looking for vector libraries for lua, I noticed most of them use tables to store the vectors themselves. This might be fine for most applications, but for games and high-performance uses, creating a table for every vector is simply too much overhead. Using C data to store and create vectors with the `ffi` library in luajit is a much more efficient method that can produce code that performs much faster and consumes a lot less memory.

So I wrote this vector library to take advantage of that fact, and made it extremely beginner-friendly and easy for everybody to use. It's also designed to be lightweight and very portable; it's only really a single file!

I know CPML also uses ffi, but mine is different enough in that it's lightweight and standalone. And getting some properties from vectors in mine is done as a simple . access instead of a method (ie, v.length vs v:length() )