### PR TITLE
remove tactile

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [baton](https://github.com/tesselode/baton) -  Input library for LÖVE that bridges the gap between keyboard and gamepad controls
 * [boipushy](https://github.com/SSYGEN/boipushy) - A simple and easy to use input handler
 * [love-microphone](https://github.com/LPGhatguy/love-microphone) - Simple microphone support for LÖVE
-* [tactile](https://github.com/tesselode/tactile) - A straightforward and flexible input library
 
 ## Lighting
 *Lighting & Shadow Libraries*


### PR DESCRIPTION
Tactile is superseded by Baton, so it may not need to be in the list. That being said, it has some historical significance, as I think a lot of people have used it, so feel free to merge this or not.