### PR TITLE
Move "deep" from 3D to Drawing after update

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 
 * [anim9](https://github.com/excessive/anim9) - 3D skeletal animation library (design to be used with IQM and IQE)
 * [bump-3dpd](https://github.com/oniietzschan/bump-3dpd) - A 3D collision detection library for Lua.
-* [DEEP](https://github.com/Nikaoto/DEEP) - Handles draw order by allowing you to specify Z axis when drawing.  
 * [IQE](https://github.com/excessive/iqe) - Inter-Quake Export loader (text)
 * [IQM](https://github.com/excessive/iqm) - Inter-Quake Model loader (binary)
 * [LÖVE3D](https://github.com/excessive/love3d) - 3D extensions to LÖVE
@@ -89,6 +88,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [renderplanet](https://github.com/meric/renderplanet/) - realistic orthographic planet rendering
 * [Sölar](https://github.com/JanWerder/soelar) - a fairly simple solar system simulator
 * [svglover](https://github.com/globalcitizen/svglover) - Library to import and display simple SVGs in LÖVE
+* [deep](https://github.com/Nikaoto/deep) - Adds Z axis; allows you to queue actions and draw calls
 
 ## Entity
 *Entity and Gameobject Managing Libraries*


### PR DESCRIPTION
Moved **deep** from **3D** to **Drawing**. It's functionality has drastically changed after the v2.0.3 update, so putting it at 3D would be misleading.