### PR TITLE
added vector.lua to the math category

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [ListBox](https://github.com/darkmetalic/ListBox) - A dynamic ListBox for LÖVE that supports touch, mouse, and keyboard inputs
 
 ## Utilities
-*Non-Game specific Library bundles, that provide reusable functions*
+*Non-Game specific Library bundles, that provide reuseable functions*
 
 * [ArrayRotation](https://gist.github.com/rm-code/4118d4a97d8cde16952199d94b84ead0) - Rotation of two dimensional arrays (square and non-square)
 * [cargo](https://github.com/bjornbytes/cargo) - Asset manager

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [hump.vector](https://hump.readthedocs.io/en/latest/vector.html) - Powerful 2D vector class
 * [MLib](https://github.com/davisdude/mlib) - Math and shape-intersection detection library written in Lua. It's aim is to be robust and easy to use
 * [shash](https://github.com/rxi/shash) - A simple, lightweight spatial hash for Lua
+* [vector.lua](https://github.com/themousery/vector.lua) - a simple vector library based on the PVector class from processing
 
 ## Music
 *Music related libraries*

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [ListBox](https://github.com/darkmetalic/ListBox) - A dynamic ListBox for LÖVE that supports touch, mouse, and keyboard inputs
 
 ## Utilities
-*Non-Game specific Library bundles, that provide reuseable functions*
+*Non-Game specific Library bundles, that provide reusable functions*
 
 * [ArrayRotation](https://gist.github.com/rm-code/4118d4a97d8cde16952199d94b84ead0) - Rotation of two dimensional arrays (square and non-square)
 * [cargo](https://github.com/bjornbytes/cargo) - Asset manager


### PR DESCRIPTION
I first learned how to use vectors, as I'm sure quite a few others did, from Daniel Shiffman's [ wonderful tutorials](https://www.youtube.com/watch?v=mWJkvxQXIa8). He used the PVector class in Processing, which I had become comfortable with before I began development with LOVE2D. Although HUMP's Vector class is very powerful, I found that it was lacking a few functions I was used to, and even took to adding them myself for my project. I ended up decided to just create my own module. This vector library has all of the functions that PVector has (even a couple more), except in a more lua-fied manner. Hopefully someone else will have the issue as me and find this as useful as I have so far. 

The repository is well-documented and I will strive to maintain it and watch for any issues.