### PR TITLE
Update Gspöt URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 
 * [CatUI](https://github.com/wilhantian/catui) - A very light-weight GUI library for LÖVE
 * [GOOi](https://github.com/tavuntu/gooi) - Android-oriented GUI library
-* [Gspöt](https://github.com/pgimeno/Gspot) - A stateful GUI lib for LÖVE
+* [Gspöt](https://notabug.org/pgimeno/Gspot) - A stateful GUI lib for LÖVE
 * [LoveFrames Fork](https://github.com/unek/LoveFrames/commits/master) - 0.10 Fork of a GUI library
 * [Love Imgui](https://github.com/slages/love-imgui) - imgui module for the LÖVE game engine
 * [Löve-Nuklear](https://github.com/keharriso/love-nuklear) - Lightweight immediate mode GUI for LÖVE games


### PR DESCRIPTION
They're using NotABug for hosting their code now (previously used GitHub).