### PR TITLE
Adding love-typescript-definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [LoveDebug](https://github.com/Ranguna/LOVEDEBUG) - Inline console-like debugger utility
 * [lurker](https://github.com/rxi/lurker) - Auto-swaps changed Lua files in a running game
 * [LÖVE API](https://github.com/love2d-community/love-api) - The complete API documentation of LÖVE in a Lua table
+* [LÖVE TypeScript Definitions](https://github.com/hazzard993/love-typescript-definitions) - Write LÖVE games with TypeScript
 * [MakeLove](https://github.com/instilledbee/MakeLove) - Automated build creation for your projects, by monitoring changes in real-time (Windows Only)
 
 ## Drawing

--- a/README.md
+++ b/README.md
@@ -339,6 +339,6 @@ Please see [CONTRIBUTING](https://github.com/love2d-community/awesome-love2d/blo
 
 * [awesome-lua](https://github.com/LewisJEllis/awesome-lua) - A list like this one, but more general and encompassing all of Lua's uses
 * [awesome-love-shaders](https://github.com/karai17/awesome-love-shaders) - A collection of shaders designed to work in LÖVE
-* [awesome-pico8](https://github.com/felipebueno/awesome-PICO-8) - A curated list of PICO-8 resources, tutorials, tools and more
+* [awesome-pico8](https://github.com/pico-8/awesome-PICO-8) - A curated list of PICO-8 resources, tutorials, tools and more
 
 Other awesome lists can be found in the [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness) list.


### PR DESCRIPTION
Made some TypeScript definitions/declarations to use with [TypeScriptToLua](https://github.com/TypeScriptToLua/TypeScriptToLua) to allow LÖVE projects to be written with TypeScript (repo instructs how).

Keeping them up to date with the wiki.

I think this provides extra assistance for LÖVE game development as TypeScript provides:

- Classes, Interfaces, mixins, other OOP
- Strong type checking

And TypeScript editors like vs-code and Sublime Text provide:

- Auto-complete
- Informational tooltips
- Error highlighting

I haven't seen Moonscript or Haxe pop up on this list yet so this would be something new.