### PR TITLE
Add selene to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [knife.base](https://github.com/airstruck/knife/blob/master/readme/base.md) - Extremely minimal base class providing single inheritance and constructors.
 * [middleclass](https://github.com/kikito/middleclass) - Simple OOP library for Lua; has inheritance, metamethods (operators), class variables and weak mixin support (class-commons)
 * [muun](https://github.com/megagrump/muun) - Moonscript compatible class implementation
+* [selene](https://github.com/novafacing/selene) - Project template for writing games in Moonscript instead of Lua without precompiling
 
 ## Performance
 *Performance measurement tools*


### PR DESCRIPTION
Selene is a very small template repo, however I spent about 6 hours reading through buried, old, forgotten forum postings and asking questions on Discord to figure out how to write my LÖVE games in Moonscript. I'd like to save others the hassle and let them either A) use my repo directly or B) just look at how I did things and do the same.