### PR TITLE
Update Love.js link

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [LoveDos](https://github.com/rxi/lovedos) - A Lua framework for 2D DOS games, implementing a subset of the LÖVE API
 * [LoveFTW](https://bitbucket.org/T-BoneISS/l-veftw) - Work-in-progress port to Windows phone 8.1
 * [LovePotion](https://github.com/TurtleP/LovePotion) - Unofficial work-in-progress implementation of the LÖVE API for Nintendo 3DS and Nintendo Switch Homebrew
-* [Love.js](https://github.com/TannerRogalsky/love.js) - LÖVE ported to the web using Emscripten
+* [Love.js](https://github.com/Davidobot/love.js) - LÖVE ported to the web using Emscripten
 * [LÖVR](https://github.com/bjornbytes/lovr) - LÖVE for virtual reality devices
 
 ## Publishing


### PR DESCRIPTION
The [current link](https://github.com/TannerRogalsky/love.js) appears to be [unmaintained](https://github.com/TannerRogalsky/love.js#unmaintained), but it links to a fork that's up-to-date. It might be wise to change the link to the fork.