### PR TITLE
Remove Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,17 +369,6 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 ## IDEs
 *Integrated Development Environments and text editor plugins*
 
-* [Atom](https://atom.io/) - A hackable text editor for the 21st Century (obsolete).
-	* [Love-Atom](https://atom.io/packages/love-atom) - Smart autocompletion for the LÖVE framework in Atom.
-	* [Autocomplete GLSL](https://atom.io/packages/autocomplete-glsl) - Adds GLSL autocompletion in Atom.
-	* [language-glsl](https://atom.io/packages/language-glsl) - OpenGL Shading Language support in Atom.
-	* [language-lua](https://atom.io/packages/language-lua) - Lua language support in Atom.
-	* [linter-luacheck](https://github.com/AtomLinter/linter-luacheck) - Lint Lua on the fly, using luacheck.
-	* [Löve Launcher](https://atom.io/packages/love-launcher) - Launch LÖVE for the current project without having to leave Atom.
-	* [Löve IDE](https://atom.io/packages/love-ide) - This package auto-installs several utilities for writing Love2D games in Atom.
-		* [Autocomplete Löve](https://atom.io/packages/autocomplete-love) - Auto-complete and snippets for LÖVE.
-		* [Hyperclick Löve](https://atom.io/packages/hyperclick-love) - A Hyperclick provider for LÖVE which shows the wiki.
-		* [linter-luaparse](https://atom.io/packages/linter-luaparse) - Lua syntax error checking in Atom.
 * [Brackets](http://brackets.io/) - A modern, open source text editor by Adobe (obsolete).
 	* [Lua Syntax Highlighter](https://github.com/ForbesLindesay/brackets-language-extensions) - Add Lua syntax highlighting in Brackets.
 	* [LÖVE Hints for Brackets.io](https://gitlab.com/sdonalcreative/brackets-love-hints/) - Provides LÖVE code hints.


### PR DESCRIPTION
Atom isn't being maintained anymore and all the links for it lead to github.blog/2022-06-08-sunsetting-atom so i think it would be a good idea to remove it