### PR TITLE
Add ShaderScan

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [ngrading](https://github.com/MikuAuahDark/NPad93/tree/master/ngrading) - Simple color grading library.
 * [Shadertoy viewer](http://love2d.org/forums/viewtopic.php?f=5&t=80885) - Run code copied from shadertoy directly or output the converted code to a LÖVE shader.
 * [Moonshine](https://github.com/vrld/moonshine) - Repository of common post-processing effects like blur, vignette, color-grading, etc.
+* [ShaderScan](https://github.com/idbrii/love-shaderscan) - Adds hot reload, includes, and better error messages for faster shader iteration.
 
 ## Testing
 *Libraries and Tools for Unit Testing*


### PR DESCRIPTION
[ShaderScan](https://github.com/idbrii/love-shaderscan) improves iteration with shaders in love2d:

* reloads shaders when they're saved
* include shaders into other shaders
* handles circular include dependencies
* output correct filename and line number in errors
* send uniforms to shaders and ignore unused errors

MIT licensed

 # Reload

If you call `ShaderScan.update` from `love.update`, it will watch for changes to your shaders and reload them if they've changed. If there are errors, ShaderScan will report the errors but keep using the previous version of the shader.

 # Better Errors

Get errors with file, line number, and the specific line that failed:

    Error: shaderscan.lua:126: Loading 'splitcolor' failed: Error validating pixel shader code:
    example/splitcolor.glsl:20: in 'splitcolor' ERROR: 'pingpon' : no matching overloaded function found
    example/splitcolor.glsl:20: in 'splitcolor' ERROR: '' : compilation terminated
    ERROR: 2 compilation errors.  No code generated.
    File: example/splitcolor.glsl
    Line:
            + overlay * pingpon(iTime / cycle_duration);

Sending a uniform that doesn't exist with `ShaderScan.safe_send` prints the error once, but doesn't fail.

 # Adds `#include`

Love doesn't support shader includes ("required extension not requested: GL_GOOGLE_include_directive") and instead of using an external shader compiler, use ShaderScan to include shaders *and* get correct file and line errors.