### PR TITLE
Add GamepadGuesser

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 *Input & Binding Libraries*
 
 * [baton](https://github.com/tesselode/baton) -  Input library for LÖVE that bridges the gap between keyboard and gamepad controls.
+* [GamepadGuesser](https://github.com/idbrii/love-gamepadguesser) - Get the right button icons for gamepads; load updated gamepad db.
 * [input](https://github.com/xiejiangzhi/input) -  Simple and powerful input library. support check operation time, sequence.
 * [Kazari](https://github.com/MikuAuahDark/Kazari) - Multitouch gesture and input library.
 * [love-microphone](https://github.com/LPGhatguy/love-microphone) - Simple microphone support for LÖVE.


### PR DESCRIPTION
[GamepadGuesser](https://github.com/idbrii/love-gamepadguesser) Guesses what a gamepad should look like and provides a default set of art that matches the input gamepad.

Simplify showing gamepad icons with gamepadguesser. It loads the extensive SDL_GameControllerDB for better gamepad support, maps joysticks to appearance (console-specific buttons like Xbox, Nintendo, ...), and builds images on demand for each GamepadButton and GamepadAxis.

You can also use gamepadguesser with your own art. The easiest way is to modify the art in gamepadguesser/assets/images/ to ensure the correct file names. It also has a low-level API that avoids any automatic magic and lets you just query information about connected gamepads.

Doesn't correctly detect in lovejs due to missing support (all gamepads appear to be xbox gamepads in web builds).

Requires love2d 11.3+

MIT licensed.