### PR TITLE
README.md: Update LÖVE Potion

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 
 * [LoveDos](https://github.com/rxi/lovedos) - A Lua framework for 2D DOS games, implementing a subset of the LÖVE API.
 * [LoveFTW](https://bitbucket.org/T-BoneISS/l-veftw) - Work-in-progress port to Windows phone 8.1.
-* [LovePotion](https://github.com/TurtleP/LovePotion) - Unofficial work-in-progress implementation of the LÖVE API for Nintendo 3DS and Nintendo Switch Homebrew.
+* [LÖVE Potion](https://github.com/lovebrew/lovepotion) - Unofficial implementation of the LÖVE for Nintendo (3DS, Switch and Wii U) Homebrew.
 * [LOVE-WrapLua](https://github.com/LukeZGD/LOVE-WrapLua) - A small and simple wrapper for OneLua, lpp-vita, and Lua Player PS3.
 * [Love.js](https://github.com/Davidobot/love.js) - LÖVE ported to the web using Emscripten.
 * [LÖVR](https://github.com/bjornbytes/lovr) - LÖVE for virtual reality devices.


### PR DESCRIPTION
Small update to fix the name, link and description. The link did auto-redirect, but using the proper link is probably preferred.