### PR TITLE
add love-build to distribution section

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [love-export](https://github.com/dmoa/love-export) - Fast and simple command-line tool that builds binaries for you. Supports Windows, macOS, and Linux.
 * [love-release](https://github.com/MisterDA/love-release) - A Lua script that automates game distribution. Supports Windows, macOS, Debian, Linux.
 * [makelove](https://github.com/pfirsich/makelove) - Advanced multi-platform tool to fuse your game written in Python 3. Supports Windows and Linux with AppImage.
+* [love-build](https://github.com/ellraiser/love-build) - Downloadable application (made in LÖVE!) that can build games for Windows, macOS, and Linux regardless of your own OS.
 * [love-deploy](https://github.com/tducasse/love-deploy) - Build and deploy games on itch.io (supports windows and web exports).
 * [love-fuser](https://github.com/MikuAuahDark/love-fuser) - Packages LÖVE Games using GitHub Actions. Supports Windows, Linux, and Android.
 


### PR DESCRIPTION
adding another build tool to the pile:
https://github.com/ellraiser/love-build

reasons I think it's different enough from the others:
- is an actual application rather than a build script/workflow action
- allows for drag+drop building but can be used in cmd line aswell
- can build cross-platform for windows/linux/macos regardless of what you use (i.e. will do windows .exe icons when building from non-windows platforms)
- is made using LÖVE 