### PR TITLE
Replace dead link to Using Tiled Maps in LÖVE with archived version

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 *Blogs and tutorials*
 
 * [learn2love](https://rvagamejams.com/learn2love/) - Book for learning programming with Lua and LÖVE (Version 11.0+).
-* [Using Tiled Maps in LÖVE](http://lua.space/gamedev/using-tiled-maps-in-love) - An article about using maps created with Tiled in your LÖVE game.
+* [Using Tiled Maps in LÖVE (archived)](https://web.archive.org/web/20230314215611/http://lua.space/gamedev/using-tiled-maps-in-love) - An article about using maps created with Tiled in your LÖVE game.
 * [Tutorial on making an Arkanoid-type game](https://github.com/noooway/love2d_arkanoid_tutorial/wiki) - A complete tutorial on how to make a breakout clone by nooowaay.
 * [Simple Game Tutorials](https://simplegametutorials.github.io/) - Tutorials for making simple games with LÖVE (Snake, Sokoban, Tetris, etc.).
 * [How to LÖVE](https://sheepolution.com/learn/book/contents) - A book by Sheepolution teaching LÖVE from the ground up.


### PR DESCRIPTION
The original link to Using Tiled Maps in LÖVE on lua.space is no longer accessible (the domain returns a DNS error).

This PR updates the reference to a Wayback Machine archived version from March 2023: https://web.archive.org/web/20230314215611/http://lua.space/gamedev/using-tiled-maps-in-love

The link label was also updated to include “(archived)” so readers are aware they are viewing a snapshot.

This ensures the learning resource remains accessible.