### PR TITLE
Downgrade to last stable 1.x awesome-lint version.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install awesome-lint
-        run: npm install -g awesome-lint
+        run: npm install -g awesome-lint@1.2.0
       - name: Run awesome-lint
         run: npx awesome-lint ./README.md


### PR DESCRIPTION
Seems versions of `awesome-lint` 2.0.0 and higher result in new linting errors, failing the pipeline for all future PRs. Pin the last known good version when installing in the workflow.