### PR TITLE
Add a new entry (likelihud) in the UI category.

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ A categorized community-driven collection of high-quality, awesome [LÖVE](http:
 * [Helium](https://github.com/qeffects/helium) - A modern, customizable, high performance retained UI framework.
 * [Inky](https://github.com/Keyslam/Inky) - Any-purpose GUI framework.
 * [Layouter](https://github.com/nekromoff/layouter) - A simple UI **grid layout** library for LÖVE 2D game engine.
+* [likelihud](https://github.com/LRDPRDX/LikeliHUD) - A simple UI library with a declarative QML-like approach of defining UI.
 * [ListBox](https://github.com/darkmetalic/ListBox) - A dynamic ListBox for LÖVE that supports touch, mouse, and keyboard inputs.
 * [Love Imgui](https://github.com/slages/love-imgui) - Imgui module for the LÖVE game engine.
 * [Löve-Nuklear](https://github.com/keharriso/love-nuklear) - Lightweight immediate mode GUI for LÖVE games.


### PR DESCRIPTION
I would like to add my lib in the list: https://github.com/LRDPRDX/LikeliHUD

The documentation is available here (it's easily accessible from the repo, but I will duplicate the link): https://lrdprdx.github.io/LikeliHUD/

It is under development and usage -- I am creating my dnd/medieval/roguelike TODO list with the usage of this lib (quite raw now):

[q-demo.webm](https://github.com/user-attachments/assets/f22a76b8-b69a-4397-ba16-f1e82d180125)

EDIT: updated the demo.
